### PR TITLE
Fix graph sampling sensitivity

### DIFF
--- a/lib/processor/dataSample.js
+++ b/lib/processor/dataSample.js
@@ -36,6 +36,8 @@
 * specific language governing permissions and limitations
 * under the License.
 */
+var samplingFactor = 0.2; // ~pixels per sample. tune the amount of sampling seed
+
 var samplers = {
   average: function (frame) {
     var sum = 0;
@@ -107,7 +109,7 @@ function _default(seriesType) {
         var extent = baseAxis.getExtent(); // Coordinste system has been resized
 
         var size = extent[1] - extent[0];
-        var rate = Math.round(data.count() / size);
+        var rate = Math.round(samplingFactor * data.count() / size);
 
         if (rate > 1) {
           var sampler;

--- a/src/processor/dataSample.js
+++ b/src/processor/dataSample.js
@@ -17,6 +17,7 @@
 * under the License.
 */
 
+var samplingFactor = 0.2; // ~pixels per sample. tune the amount of sampling seed
 
 var samplers = {
     average: function (frame) {
@@ -84,7 +85,7 @@ export default function (seriesType) {
                 var extent = baseAxis.getExtent();
                 // Coordinste system has been resized
                 var size = extent[1] - extent[0];
-                var rate = Math.round(data.count() / size);
+                var rate = Math.round(samplingFactor * data.count() / size);
                 if (rate > 1) {
                     var sampler;
                     if (typeof sampling === 'string') {


### PR DESCRIPTION
This commit reduces the sensitivity of graph sampling. It equates to sampling attempting to target ~5points/pixel instead of 1point/pixel on a graph output.

For example instead of sampling beginning to occur at 3-4 weeks of FitMachine data, the sampling will only start at about 4-5 months, and is also less aggressive as more data is loaded.

here is the difference of a FitMachine chart over two years
<img width="2560" alt="Screen Shot 2019-08-28 at 2 41 25 pm" src="https://user-images.githubusercontent.com/6194521/63826770-02c81f80-c9a4-11e9-9531-f8cb64719c2f.png">

Not included in this commit (which is in the dashboard) is the change from 'average' to 'nearest' calculation, which  with the less aggressive sampling tends to do a mostly faithful representation of the data without any sampling applied.

<img width="2560" alt="Screen Shot 2019-08-28 at 2 37 09 pm" src="https://user-images.githubusercontent.com/6194521/63827041-f8f2ec00-c9a4-11e9-989f-af37a8590c7c.png">
